### PR TITLE
Fix critical grammar errors in Polish translation.

### DIFF
--- a/src/BlueskyClient.Uwp/MultilingualResources/BlueskyClient.Uwp.pl.xlf
+++ b/src/BlueskyClient.Uwp/MultilingualResources/BlueskyClient.Uwp.pl.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="pl" original="BLUESKYCLIENT.UWP/STRINGS/EN-US/RESOURCES.RESW" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
@@ -8,7 +8,7 @@
       <group id="BLUESKYCLIENT.UWP/STRINGS/EN-US/RESOURCES.RESW" datatype="resx">
         <trans-unit id="AppPasswordHelpText" translate="yes" xml:space="preserve">
           <source>What's an App Password?</source>
-          <target state="translated">Co to jest hasło do aplikacji?</target>
+          <target state="translated">Czym jest hasło do aplikacji?</target>
         </trans-unit>
         <trans-unit id="BackText" translate="yes" xml:space="preserve">
           <source>Back</source>
@@ -20,19 +20,19 @@
         </trans-unit>
         <trans-unit id="CloseText" translate="yes" xml:space="preserve">
           <source>Close</source>
-          <target state="translated">Zamykać</target>
+          <target state="translated">Zamknij</target>
         </trans-unit>
         <trans-unit id="FollowersText" translate="yes" xml:space="preserve">
           <source>followers</source>
-          <target state="translated">Zwolenników</target>
+          <target state="translated">obserwujących</target>
         </trans-unit>
         <trans-unit id="FollowingText" translate="yes" xml:space="preserve">
           <source>following</source>
-          <target state="translated">następujący</target>
+          <target state="translated">obserwowanych</target>
         </trans-unit>
         <trans-unit id="HomeText" translate="yes" xml:space="preserve">
           <source>Home</source>
-          <target state="translated">Dom</target>
+          <target state="translated">Główna</target>
         </trans-unit>
         <trans-unit id="IdentifierBoxPlaceholder" translate="yes" xml:space="preserve">
           <source>Bluesky email or username</source>
@@ -52,15 +52,15 @@
         </trans-unit>
         <trans-unit id="NotificationsFollowedText" translate="yes" xml:space="preserve">
           <source>{0} followed you</source>
-          <target state="translated">{0} podążał za tobą</target>
+          <target state="translated">{0} teraz Cię obserwuje</target>
         </trans-unit>
         <trans-unit id="NotificationsLikedText" translate="yes" xml:space="preserve">
           <source>{0} liked your post</source>
-          <target state="translated">{0} polubił Twój post</target>
+          <target state="translated">{0} lubi Twój post</target>
         </trans-unit>
         <trans-unit id="NotificationsRepostedText" translate="yes" xml:space="preserve">
           <source>{0} reposted your post</source>
-          <target state="translated">{0} ponownie opublikował Twój post</target>
+          <target state="translated">{0} zrepostował(a) Twój post</target>
         </trans-unit>
         <trans-unit id="NotificationsText" translate="yes" xml:space="preserve">
           <source>Notifications</source>
@@ -68,7 +68,7 @@
         </trans-unit>
         <trans-unit id="OkayText" translate="yes" xml:space="preserve">
           <source>Okay</source>
-          <target state="translated">Porządku</target>
+          <target state="translated">Okej</target>
         </trans-unit>
         <trans-unit id="PasswordBoxPlaceholder" translate="yes" xml:space="preserve">
           <source>Your special App Password</source>
@@ -88,7 +88,7 @@
         </trans-unit>
         <trans-unit id="RepostCaption" translate="yes" xml:space="preserve">
           <source>Reposted by {0}</source>
-          <target state="translated">Ponownie opublikowane przez {0}</target>
+          <target state="translated">Repostowane przez {0}</target>
         </trans-unit>
         <trans-unit id="SendFeedbackText" translate="yes" xml:space="preserve">
           <source>Send feedback</source>
@@ -104,15 +104,15 @@
         </trans-unit>
         <trans-unit id="SignInText" translate="yes" xml:space="preserve">
           <source>Sign in</source>
-          <target state="translated">Rejestrowanie</target>
+          <target state="translated">Rejestracja</target>
         </trans-unit>
         <trans-unit id="SignOutDialogMessage" translate="yes" xml:space="preserve">
           <source>Are you sure? You will return to the sign in page.</source>
-          <target state="translated">Czy na pewno? Nastąpi powrót do strony logowania.</target>
+          <target state="translated">Na pewno? Nastąpi powrót do strony logowania.</target>
         </trans-unit>
         <trans-unit id="SignOutDialogTitle" translate="yes" xml:space="preserve">
           <source>Signing out</source>
-          <target state="translated">Wylogowywanie się</target>
+          <target state="translated">Wylogowywanie</target>
         </trans-unit>
         <trans-unit id="SignOutText" translate="yes" xml:space="preserve">
           <source>Sign out</source>


### PR DESCRIPTION
Auto-translating removes a whole lot of context in Polish, where words can have a ton of meanings. Everything should be fixed to the best of my ability. Beautiful app.